### PR TITLE
Setup.py no longer installs test packages.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -123,7 +123,7 @@ setup(
     platforms=['any'],
     license='BSD',
     keywords='asyncio service bootsteps graph coroutine',
-    packages=find_packages(exclude=['ez_setup', 'tests', 'tests.*']),
+    packages=find_packages(exclude=['t']),
     include_package_data=True,
     # PEP-561: https://www.python.org/dev/peps/pep-0561/
     package_data={'mode': ['py.typed']},


### PR DESCRIPTION
I found that v1.15.1 installs test packages along with the regular mode package.

This PR excludes the `t` package containing the tests and removes excludes of non-existant packages from `setup.py`.