### PR TITLE
Add minimum version of dependency on colorlog

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,1 +1,1 @@
-colorlog
+colorlog>=2.9.0


### PR DESCRIPTION
Mode depends on `colorlog.TTYColoredFormatter` which was [added in v2.9.0.](https://github.com/borntyping/python-colorlog/commit/7abe01f4243db485dd8f772a712062070c1d5258) I propose to add a minimum version of the dependency. This allows other developers to specify mode dependencies more easily in their respective package managers.