### PR TITLE
Add tests to PyPI tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,6 +7,7 @@ include setup.py
 recursive-include docs *
 recursive-include extra/*
 recursive-include examples *
+recursive-include t *
 recursive-include mode *.py *.html *.typed
 recursive-include requirements *.txt *.rst
 


### PR DESCRIPTION
I am currently trying to package `mode-2.0.3` for Gentoo Linux. Gentoo packages are generally compiled from source. The installation process involves a test phase which executes the package's tests in order to verify that the installed software is working. However, the PyPI tarball for `mode-2.0.3` does not include the tests.

This PR adds the `t` directory to the artefact generated by `python setup.py sdist`. Thereby, future release tarballs should contain the tests which potentially helps other package maintainers as well. A small change to `MANIFEST.in` should already to the trick :)