### PR TITLE
Add stream to default formatters to fix breaking change colorlog 4.0

### DIFF
--- a/mode/utils/logging.py
+++ b/mode/utils/logging.py
@@ -74,6 +74,7 @@ DEFAULT_FORMATTERS = {
         '()': 'mode.utils.logging.ExtensionFormatter',
         'format': DEFAULT_COLOR_FORMAT,
         'log_colors': DEFAULT_COLORS,
+        'stream': sys.stdout
     },
 }
 

--- a/mode/utils/logging.py
+++ b/mode/utils/logging.py
@@ -74,7 +74,7 @@ DEFAULT_FORMATTERS = {
         '()': 'mode.utils.logging.ExtensionFormatter',
         'format': DEFAULT_COLOR_FORMAT,
         'log_colors': DEFAULT_COLORS,
-        'stream': sys.stdout
+        'stream': sys.stdout,
     },
 }
 


### PR DESCRIPTION
Fixes breaking change introduced in colorlog 4.0 today where log stream no longer has a default of stdout. Causes workers to exit immediately. 

https://github.com/borntyping/python-colorlog/commit/40280b4bb36d8ad1a8bf1cfaa159a4a9066b1126#diff-58e8d864ceb9f791b89e0b6364b5e233

Note that tests initialize logging.config.dictConfig as MagicMock so I don't believe colorlog is actually invoked in the test suite. 
