### PR TITLE
Service: Use add_dependecy() to add child dependency in _actually_start

### DIFF
--- a/mode/services.py
+++ b/mode/services.py
@@ -716,7 +716,8 @@ class Service(ServiceBase, ServiceCallbacks):
         """Start the service."""
         for _ in [1]:  # to use break
             if not self.restart_count:
-                self._children.extend(self.on_init_dependencies())
+                for dep in self.on_init_dependencies():
+                    self.add_dependency(dep)
                 await self.on_first_start()
                 if self.should_stop:
                     break


### PR DESCRIPTION
.## Description

More information in robinhood/faust#302 as this was uncovered trying to fix robinhood/faust#301

I believe the fact that `init_dependency`s are directly added to `_children` instead of using `add_dependency` is a bug. As is today, dependencies that are added via `init_depedency` each have its own root beacon, and are unable to properly walk the tree. This causes issues where the CrashingSupervisor isn't able to work as documented because it's unable to fully crash the tree.