### PR TITLE
examples/tutorial.py: fix refs to App dependencies

### DIFF
--- a/examples/tutorial.py
+++ b/examples/tutorial.py
@@ -110,16 +110,16 @@ class App(Service):
 
     def on_init_dependencies(self) -> None:
         return [
-            self.app.websockets,
-            self.app.webserver,
-            self.app.user_cache,
+            self.websockets,
+            self.webserver,
+            self.user_cache,
         ]
 
     async def on_start(self) -> None:
         import pydot
         import io
         o = io.StringIO()
-        beacon = self.app.beacon.root or self.app.beacon
+        beacon = self.beacon.root or self.beacon
         beacon.as_graph().to_dot(o)
         graph, = pydot.graph_from_dot_data(o.getvalue())
         print('WRITING GRAPH TO image.png')


### PR DESCRIPTION
Trying to run the tutorial example raises:
`AttributeError: 'App' object has no attribute 'app'`

I guess, `self.app` is some leftover of a prev tutorial version? This lil commit fixes this.