### PR TITLE
Add Service method to remove dependency at runtime

### DIFF
--- a/mode/services.py
+++ b/mode/services.py
@@ -557,6 +557,14 @@ class Service(ServiceBase, ServiceCallbacks):
             await service.maybe_start()
         return service
 
+    async def remove_dependency(self, service: ServiceT) -> ServiceT:
+        """Stop and remove dependency of this service."""
+        await service.stop()
+        self._children.remove(service)
+        if service.beacon is not None:
+            service.beacon.detach(self.beacon)
+        return service
+
     async def add_async_context(self, context: AsyncContextManager) -> Any:
         if isinstance(context, AsyncContextManager):
             return await self.async_exit_stack.enter_async_context(context)

--- a/mode/utils/trees.py
+++ b/mode/utils/trees.py
@@ -69,6 +69,13 @@ class Node(NodeT[_T]):
         parent.add(self)
         return self
 
+    def detach(self, parent: NodeT[_T]) -> NodeT[_T]:
+        """Detach this node from `parent` node."""
+        self.parent.discard(self)
+        self.parent = None
+        self.root = None
+        return self
+
     def add(self, data: _T) -> None:
         """Add node as a child node."""
         self.children.append(data)

--- a/t/functional/test_service.py
+++ b/t/functional/test_service.py
@@ -126,6 +126,16 @@ async def test_start_stop_restart_complex():
         assert service.y.z.x._started.is_set()
 
 
+@pytest.mark.asyncio
+async def test_remove_dependency():
+    async with Complex() as service:
+        x = service.x
+        await service.remove_dependency(x)
+        assert x._stopped.is_set()
+        assert x not in service._children
+        assert x.beacon not in list(service.beacon.traverse())
+
+
 async def crash(service, exc):
     try:
         raise exc

--- a/t/functional/utils/test_trees.py
+++ b/t/functional/utils/test_trees.py
@@ -44,6 +44,11 @@ def test_Node():
     assert node5.root is node
     assert node5 in node4.children
 
+    node5.detach(node4)
+    assert node5.parent is None
+    assert node5.root is None
+    assert node5 not in node4.children
+
     node.children.append(11)
     assert str(node.as_graph()) == '''\
 303(3)

--- a/t/unit/test_services.py
+++ b/t/unit/test_services.py
@@ -264,6 +264,14 @@ class test_Service:
         s2.maybe_start.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_remove_dependency(self, *, service):
+        s2 = Mock(stop=AsyncMock())
+        service.add_dependency(s2)
+        service._started.set()
+        await service.remove_dependency(s2)
+        s2.stop.coro.assert_called_once_with()
+
+    @pytest.mark.asyncio
     async def test_add_async_context__non_async(self, *, service):
 
         class Cx(ContextManager):

--- a/t/unit/test_services.py
+++ b/t/unit/test_services.py
@@ -272,6 +272,13 @@ class test_Service:
         s2.stop.coro.assert_called_once_with()
 
     @pytest.mark.asyncio
+    async def test_remove_dependency__no_beacon(self, *, service):
+        s2 = Mock(stop=AsyncMock())
+        s2.beacon = None
+        service.add_dependency(s2)
+        await service.remove_dependency(s2)
+
+    @pytest.mark.asyncio
     async def test_add_async_context__non_async(self, *, service):
 
         class Cx(ContextManager):


### PR DESCRIPTION
Add a `Service.remove_dependency` method that stops and removes a child service.

Follow-up to https://github.com/robinhood/faust/issues/398

Let me know if I missed something or if the tests don't make sense. I tried to follow what was there for the existing methods but I'm not 100% familiar with the codebase...
