### PR TITLE
Add crontab timer function to run periodic job

### DIFF
--- a/docs/reference/mode.utils.cron.rst
+++ b/docs/reference/mode.utils.cron.rst
@@ -1,0 +1,11 @@
+=====================================================
+ ``mode.utils.cron``
+=====================================================
+
+.. contents::
+    :local:
+.. currentmodule:: mode.utils.cron
+
+.. automodule:: mode.utils.cron
+    :members:
+    :undoc-members:

--- a/mode/utils/cron.py
+++ b/mode/utils/cron.py
@@ -1,0 +1,16 @@
+"""Crontab Utilities."""
+from datetime import datetime, tzinfo
+import time
+from croniter.croniter import croniter
+
+
+def secs_for_next(cron_format: str, tz: tzinfo = None) -> float:
+    """Return seconds until next execution given Crontab style format."""
+    now_ts = time.time()
+    # If we have a tz object we'll make now timezone aware, and
+    # if not will set now to be the current timestamp (tz
+    # unaware)
+    # If we have tz, now will be a datetime, if not an integer
+    now = tz and datetime.now(tz) or now_ts
+    cron_it = croniter(cron_format, start_time=now)
+    return cron_it.get_next(float) - now_ts

--- a/mode/utils/cron.py
+++ b/mode/utils/cron.py
@@ -1,6 +1,7 @@
 """Crontab Utilities."""
-from datetime import datetime, tzinfo
 import time
+from typing import cast
+from datetime import datetime, tzinfo
 from croniter.croniter import croniter
 
 
@@ -13,4 +14,4 @@ def secs_for_next(cron_format: str, tz: tzinfo = None) -> float:
     # If we have tz, now will be a datetime, if not an integer
     now = tz and datetime.now(tz) or now_ts
     cron_it = croniter(cron_format, start_time=now)
-    return cron_it.get_next(float) - now_ts
+    return cast(float, cron_it.get_next(float)) - now_ts

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -2,3 +2,4 @@ colorlog>=2.9.0
 aiocontextvars>=0.2 ; python_version<'3.7'
 mypy_extensions
 typing_extensions; python_version<'3.8'
+croniter>=0.3.16

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,5 @@
 hypothesis>=3.31
+freezegun>=0.3.11
 pytest-aiofiles>=0.2.0
 pytest-asyncio>=0.8
 pytest-base-url>=1.4.1

--- a/t/unit/utils/test_cron.py
+++ b/t/unit/utils/test_cron.py
@@ -1,0 +1,30 @@
+import pytz
+from freezegun import freeze_time
+from mode.utils.cron import secs_for_next
+
+SECS_IN_HOUR = 60 * 60
+
+
+@freeze_time('2000-01-01 00:00:00')
+def test_secs_for_next():
+    every_minute_cron_format = '*/1 * * * *'
+    assert secs_for_next(every_minute_cron_format) == 60
+
+    every_8pm_cron_format = '0 20 * * *'
+    assert secs_for_next(every_8pm_cron_format) == 20 * SECS_IN_HOUR
+
+    every_4th_july_1pm_cron_format = '0 13 4 7 *'
+    days_until_4th_july = 31 + 28 + 31 + 30 + 31 + 30 + 4
+    secs_until_4th_july = SECS_IN_HOUR * 24 * days_until_4th_july
+    secs_until_1_pm = 13 * SECS_IN_HOUR
+    total_secs = secs_until_4th_july + secs_until_1_pm
+    assert secs_for_next(every_4th_july_1pm_cron_format) == total_secs
+
+
+@freeze_time('2000-01-01 00:00:00')
+def test_secs_for_next_with_tz():
+    pacific = pytz.timezone('US/Pacific')
+
+    every_8pm_cron_format = '0 20 * * *'
+    # In Pacific time it's 16:00 so only 4 hours until 8:00pm
+    assert secs_for_next(every_8pm_cron_format, tz=pacific) == 4 * SECS_IN_HOUR


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.fauststream.com/en/master/contributing.html).

## Description

Hey, Ask. Thanks for your project.

I'm using `mode` as base framework to build some applications, but I found missing some features about `Service.timer` and `Service.task`.

So I try to add a crontab based timer into `mode`, and the major implementation is ported from `faust` code base.

It won't be better you could help to review this PR. If there are some problems, I can follow your instruction to improve them.

Would you like to merge this function into master branch and release a new version?

Regards.

---

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
